### PR TITLE
use time.perf_counter() instead of time.clock()

### DIFF
--- a/anytime/AnytimeAlgorithm2.py
+++ b/anytime/AnytimeAlgorithm2.py
@@ -31,9 +31,9 @@ class AnytimeAlgorithm(metaclass=abc.ABCMeta):
         * "iterations" iterations have passed (if iterations is given)
         """
         self.iteration = 0
-        start = time.clock()   # current time in seconds
+        start = time.perf_counter()   # current time in seconds
         while True:
-            if seconds is not None and time.clock()-start>seconds:
+            if seconds is not None and time.perf_counter()-start>seconds:
                 break
             if iterations is not None and self.iteration>=iterations:
                 break


### PR DESCRIPTION
Hi Erel! time.clock() was removed in Python 3.8. time.perf_counter() seems to be similar enough.